### PR TITLE
Fix logo path and waitlist email duplicate rule

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -287,8 +287,11 @@ export default function HomePage() {
           setIsSubmitted(false)
           setFormData({ name: '', email: '' })
         }, 3000)
+      } else if (response.status === 409) {
+        // Duplicate email
+        setErrorMessage('User with this email exists')
       } else {
-        // Handle server errors (e.g., user already exists)
+        // Handle other server errors
         setErrorMessage(data.message || 'An unexpected error occurred. Please try again.')
       }
     } catch (error) {
@@ -418,6 +421,7 @@ export default function HomePage() {
                 
                 
                 <Image
+                  unoptimized
                   src="/logo.png"
                   alt="EliteScore logo with high-quality gradient dotted ring"
                   width={700}

--- a/backend-server.js
+++ b/backend-server.js
@@ -45,12 +45,12 @@ app.post('/v1/auth/pre-signup', (req, res) => {
     }
     
     // Check if email already exists
-    const exists = betaSignups.find(signup => signup.email === email);
-    if (exists) {
+    const emailExists = betaSignups.some(signup => signup.email === email);
+    if (emailExists) {
         console.log('Duplicate email detected:', email);
         return res.status(409).json({
             success: false,
-            message: "User with this email already exists",
+            message: "User with this email exists",
             data: null
         });
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export const config = {
-  matcher: ['/((?!_next|static|public|favicon.ico|robots.txt|sitemap.xml|assets|images|fonts).*)'],
+  matcher: ['/((?!_next|static|public|favicon.ico|robots.txt|sitemap.xml|assets|images|fonts|logo.png).*)'],
 };
 
 export function middleware(req: NextRequest) {


### PR DESCRIPTION
## Summary
- ensure public logo served from root without middleware redirect
- enforce email-only duplicate check on waitlist and show proper message

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(aborted: prompts for configuration)*
- `npm run type-check`
- `curl -I http://localhost:3000/logo.png`
- `curl -s -o /tmp/resp2.json -w "%{http_code}" -H "Content-Type: application/json" -d '{"username":"Alice","email":"alice1@example.com"}' http://localhost:8081/v1/auth/pre-signup`
- `curl -s -o /tmp/resp3.json -w "%{http_code}" -H "Content-Type: application/json" -d '{"username":"Bob","email":"alice1@example.com"}' http://localhost:8081/v1/auth/pre-signup`
- `curl -s -o /tmp/resp4.json -w "%{http_code}" -H "Content-Type: application/json" -d '{"username":"Alice","email":"alice2@example.com"}' http://localhost:8081/v1/auth/pre-signup`

------
https://chatgpt.com/codex/tasks/task_e_689b983c93108321a3a6705f626ab228