### PR TITLE
fix: serve public assets without redirect

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -6,6 +6,11 @@ export const config = {
 };
 
 export function middleware(req: NextRequest) {
-  if (req.nextUrl.pathname === '/') return NextResponse.next();
+  const { pathname } = req.nextUrl;
+  // Allow requests for files (e.g., images) and the root path to pass through
+  if (pathname === '/' || pathname.includes('.')) {
+    return NextResponse.next();
+  }
+  // Redirect all other routes to the landing page
   return NextResponse.redirect(new URL('/', req.url));
 }


### PR DESCRIPTION
## Summary
- allow requests for static files to bypass middleware redirect

## Testing
- `npm run build`
- `curl -I http://localhost:4000/calin.jpeg`
- `curl -I "http://localhost:4000/_next/image?url=%2Fcalin.jpeg&w=64&q=75"`


------
https://chatgpt.com/codex/tasks/task_e_689c65e948b883219566b57a3c9bf6dd